### PR TITLE
[DM-5740] Create and deploy an Ansible Galaxy role to install cloud packages for LSST SQuaRE infrastructure.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+---
+language: python
+python: "2.7"
+
+# Use the new container infrastructure
+sudo: false
+
+# Install ansible
+addons:
+  apt:
+    packages:
+    - python-pip
+
+install:
+  # Install ansible
+  - pip install ansible
+
+  # Check ansible version
+  - ansible --version
+
+  # Create ansible.cfg with correct roles_path
+  - printf '[defaults]\nroles_path=../' >ansible.cfg
+
+script:
+  # Basic role syntax check
+  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 JMatt Peterson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ansible-java-packages
 
 [![Build Status](https://travis-ci.org/lsst-sqre/ansible-java-packages.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-java-packages)
 
-Install java packages for LSST SQuaRE infrastructure.
+Install java using packaging for LSST SQuaRE infrastructure.
 
 Example Playbook
 ----------------

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+ansible-java-packages
+=====================
+
+[![Build Status](https://travis-ci.org/jmatt/ansible-java-packages.svg?branch=master)](https://travis-ci.org/jmatt/ansible-java-packages)
+
+Install java packages for LSST SQuaRE infrastructure.
+
+Example Playbook
+----------------
+
+    - hosts: servers
+      roles:
+         - { role: jmatt.java-packages }
+
+License
+-------
+
+See the [LICENSE file](/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-java-packages
 =====================
 
-[![Build Status](https://travis-ci.org/jmatt/ansible-java-packages.svg?branch=master)](https://travis-ci.org/jmatt/ansible-java-packages)
+[![Build Status](https://travis-ci.org/lsst-sqre/ansible-java-packages.svg?branch=master)](https://travis-ci.org/lsst-sqre/ansible-java-packages)
 
 Install java packages for LSST SQuaRE infrastructure.
 
@@ -10,7 +10,7 @@ Example Playbook
 
     - hosts: servers
       roles:
-         - { role: jmatt.java-packages }
+         - { role: lsst-sqre.java-packages }
 
 License
 -------

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,4 +24,5 @@ galaxy_info:
   galaxy_tags:
     - java
     - jvm
+  version: 0.1.0
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,27 @@
+galaxy_info:
+  author: J. Matt Peterson
+  description: LSST SQuaRE's java packages.
+  company: LSST SQuaRE
+  issue_tracker_url: https://github.com/lsst-sqre/ansible-java-packages/issues
+  license: MIT
+  min_ansible_version: 2.0
+  platforms:
+  - name: EL
+    versions:
+      - 7
+  - name: Ubuntu
+    versions:
+      - trusty
+      - xenial
+  #- name: Debian
+  #  versions:
+  #  - all
+  #  - etch
+  #  - jessie
+  #  - lenny
+  #  - squeeze
+  #  - wheezy
+  galaxy_tags:
+    - java
+    - jvm
+dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,17 +13,10 @@ galaxy_info:
     versions:
       - trusty
       - xenial
-  #- name: Debian
-  #  versions:
-  #  - all
-  #  - etch
-  #  - jessie
-  #  - lenny
-  #  - squeeze
-  #  - wheezy
   galaxy_tags:
     - system
     - java
     - jvm
-  version: 0.1.0
+    - centos
+    - ubuntu
 dependencies: []

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,0 +1,8 @@
+---
+# Install java packages on debian based distributions.
+
+- name: Install openjdk repo.
+  apt_repository: repo='ppa:openjdk-r/ppa'
+
+- name: Install the openjdk 1.8 package.
+  apt: name=openjdk-8-jdk state=latest update_cache=yes install_recommends=no

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# tasks file for java-packages
+
+- include: redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: debian.yml
+  when: ansible_os_family == 'Debian'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,0 +1,8 @@
+---
+# Install java packages on redhat based distributions.
+
+- name: Install EPEL.
+  yum: name=epel-release state=present
+
+- name: Install the openjdk 1.8 package.
+  yum: name=java-1.8.0-openjdk-headless.x86_64 state=installed

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,0 +1,1 @@
+localhost

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ansible-java-packages


### PR DESCRIPTION
Create and deploy an Ansible Galaxy role to install java packages for LSST SQuaRE infrastructure.

- [x] Install java (open-jdk) through the distribution's packaging system.
- [x] Verify using travis.ci.
- [x] Available as Ansible Galaxy role lsst-sqre.java-packages.